### PR TITLE
Update focus style of links and fix contrast issues for btn-outline-info over bg-light

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/uofg-styles",
-  "version": "3.0.2-rc.3",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/uofg-styles",
-      "version": "3.0.2-rc.3",
+      "version": "3.0.2",
       "license": "ISC",
       "devDependencies": {
         "autoprefixer": "^10.4.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/uofg-styles",
-  "version": "3.0.1",
+  "version": "3.0.2-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/uofg-styles",
-      "version": "3.0.1",
+      "version": "3.0.2-rc.0",
       "license": "ISC",
       "devDependencies": {
         "autoprefixer": "^10.4.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/uofg-styles",
-  "version": "3.0.2-rc.1",
+  "version": "3.0.2-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/uofg-styles",
-      "version": "3.0.2-rc.1",
+      "version": "3.0.2-rc.2",
       "license": "ISC",
       "devDependencies": {
         "autoprefixer": "^10.4.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/uofg-styles",
-  "version": "3.0.2-rc.0",
+  "version": "3.0.2-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/uofg-styles",
-      "version": "3.0.2-rc.0",
+      "version": "3.0.2-rc.1",
       "license": "ISC",
       "devDependencies": {
         "autoprefixer": "^10.4.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/uofg-styles",
-  "version": "3.0.2-rc.2",
+  "version": "3.0.2-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/uofg-styles",
-      "version": "3.0.2-rc.2",
+      "version": "3.0.2-rc.3",
       "license": "ISC",
       "devDependencies": {
         "autoprefixer": "^10.4.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/uofg-styles",
-  "version": "3.0.2-rc.0",
+  "version": "3.0.2-rc.1",
   "description": "A customized version of Bootstrap used for University of Guelph web pages",
   "main": "dist/index.css",
   "unpkg": "dist/index.css",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/uofg-styles",
-  "version": "3.0.2-rc.2",
+  "version": "3.0.2-rc.3",
   "description": "A customized version of Bootstrap used for University of Guelph web pages",
   "main": "dist/index.css",
   "unpkg": "dist/index.css",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/uofg-styles",
-  "version": "3.0.2-rc.3",
+  "version": "3.0.2",
   "description": "A customized version of Bootstrap used for University of Guelph web pages",
   "main": "dist/index.css",
   "unpkg": "dist/index.css",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/uofg-styles",
-  "version": "3.0.1",
+  "version": "3.0.2-rc.0",
   "description": "A customized version of Bootstrap used for University of Guelph web pages",
   "main": "dist/index.css",
   "unpkg": "dist/index.css",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/uofg-styles",
-  "version": "3.0.2-rc.1",
+  "version": "3.0.2-rc.2",
   "description": "A customized version of Bootstrap used for University of Guelph web pages",
   "main": "dist/index.css",
   "unpkg": "dist/index.css",

--- a/src/index.css
+++ b/src/index.css
@@ -11077,6 +11077,14 @@ a:active,
 a:focus {
   outline: 2px solid var(--uog-color-body-copy-link) !important;
 }
+.bg-light a:active,
+.bg-light a:focus {
+  outline: var(--uog-color-body-copy-link-on-light) !important;
+}
+.bg-dark a:active,
+.bg-dark a:focus {
+  outline: var(--uog-color-body-copy-link-on-dark) !important;
+}
 .author {
   border-left: 3px solid var(--uog-color-yellow);
   padding-left: 2rem;

--- a/src/index.css
+++ b/src/index.css
@@ -10477,10 +10477,17 @@ a.btn-info {
   background-color: transparent;
   display: inline-block !important;
 }
+.bg-light .btn-outline-info {
+  color: var(--uog-color-body-copy-link-on-light) !important;
+}
 .btn-outline-info.active,
 .btn-outline-info:active,
 .btn-outline-info:focus,
-.btn-outline-info:hover {
+.btn-outline-info:hover,
+.bg-light .btn-outline-info.active,
+.bg-light .btn-outline-info:active,
+.bg-light .btn-outline-info:focus,
+.bg-light .btn-outline-info:hover {
   background-color: var(--uog-color-blue) !important;
   border-color: var(--uog-color-blue) !important;
   color: #fff !important;
@@ -10800,8 +10807,7 @@ a:hover {
   color: var(--uog-color-body-copy-link-on-dark);
 }
 .bg-light a,
-.table-striped a,
-.bg-light a.btn-outline-info {
+.table-striped a {
   color: var(--uog-color-body-copy-link-on-light);
 }
 .site-content ul.menu.list-group {

--- a/src/index.css
+++ b/src/index.css
@@ -11079,11 +11079,11 @@ a:focus {
 }
 .bg-light a:active,
 .bg-light a:focus {
-  outline: var(--uog-color-body-copy-link-on-light) !important;
+  outline-color: var(--uog-color-body-copy-link-on-light) !important;
 }
 .bg-dark a:active,
 .bg-dark a:focus {
-  outline: var(--uog-color-body-copy-link-on-dark) !important;
+  outline-color: var(--uog-color-body-copy-link-on-dark) !important;
 }
 .author {
   border-left: 3px solid var(--uog-color-yellow);

--- a/src/index.css
+++ b/src/index.css
@@ -10261,6 +10261,7 @@ a.btn:hover {
   background-color: var(--uog-color-red-focus) !important;
   border-color: var(--uog-color-red-focus) !important;
   color: var(--uog-color-red-contrast) !important;
+  outline: none !important;
 }
 .btn-secondary {
   color: var(--uog-color-black-contrast) !important;
@@ -10286,6 +10287,7 @@ a.btn:hover {
   background-color: var(--uog-color-black-focus) !important;
   border-color: var(--uog-color-black-focus) !important;
   color: var(--uog-color-black-contrast) !important;
+  outline: none !important;
 }
 .btn-info {
   color: var(--uog-color-blue-contrast) !important;
@@ -10311,6 +10313,7 @@ a.btn:hover {
   background-color: var(--uog-color-blue-focus) !important;
   border-color: var(--uog-color-blue-focus) !important;
   color: var(--uog-color-blue-contrast) !important;
+  outline: none !important;
 }
 a.btn-info {
   color: var(--uog-color-blue-contrast) !important;
@@ -10339,6 +10342,7 @@ a.btn-info {
   background-color: var(--uog-color-green-focus) !important;
   border-color: var(--uog-color-green-focus) !important;
   color: var(--uog-color-green-contrast) !important;
+  outline: none !important;
 }
 .btn-warning {
   color: #fff !important;
@@ -10364,6 +10368,7 @@ a.btn-info {
   background-color: #a12b00 !important;
   border-color: #a12b00 !important;
   color: #fff !important;
+  outline: none !important;
 }
 .btn-danger {
   color: var(--uog-color-red-contrast) !important;
@@ -10389,6 +10394,7 @@ a.btn-info {
   background-color: var(--uog-color-red-focus) !important;
   border-color: var(--uog-color-red-focus) !important;
   color: var(--uog-color-red-contrast) !important;
+  outline: none !important;
 }
 .btn-white {
   color: #fff !important;
@@ -10414,6 +10420,7 @@ a.btn-info {
   background-color: #d5d5d5 !important;
   border-color: #d5d5d5 !important;
   color: #fff !important;
+  outline: none !important;
 }
 .btn-black {
   color: #fff !important;
@@ -10439,6 +10446,7 @@ a.btn-info {
   background-color: var(--uog-color-black-focus) !important;
   border-color: var(--uog-color-black-focus) !important;
   color: #fff !important;
+  outline: none !important;
 }
 .btn-outline-primary {
   color: var(--uog-color-red) !important;
@@ -10454,6 +10462,7 @@ a.btn-info {
   background-color: var(--uog-color-red) !important;
   border-color: var(--uog-color-red) !important;
   color: #fff !important;
+  outline: none !important;
 }
 .btn-outline-secondary {
   color: var(--uog-color-black) !important;
@@ -10469,6 +10478,7 @@ a.btn-info {
   background-color: var(--uog-color-black) !important;
   border-color: var(--uog-color-black) !important;
   color: #fff !important;
+  outline: none !important;
 }
 .btn-outline-info {
   color: var(--uog-color-blue) !important;
@@ -10491,6 +10501,7 @@ a.btn-info {
   background-color: var(--uog-color-blue) !important;
   border-color: var(--uog-color-blue) !important;
   color: #fff !important;
+  outline: none !important;
 }
 .btn-outline-success {
   color: var(--uog-color-green) !important;
@@ -10506,6 +10517,7 @@ a.btn-info {
   background-color: var(--uog-color-green) !important;
   border-color: var(--uog-color-green) !important;
   color: #fff !important;
+  outline: none !important;
 }
 .btn-outline-warning {
   color: #d43900 !important;
@@ -10521,6 +10533,7 @@ a.btn-info {
   background-color: #d43900 !important;
   border-color: #d43900 !important;
   color: #fff !important;
+  outline: none !important;
 }
 .btn-outline-danger {
   color: var(--uog-color-red) !important;
@@ -10536,6 +10549,7 @@ a.btn-info {
   background-color: var(--uog-color-red-focus) !important;
   border-color: var(--uog-color-red-focus) !important;
   color: var(--uog-color-red-contrast) !important;
+  outline: none !important;
 }
 .btn-outline-white {
   color: #eee !important;
@@ -10551,6 +10565,7 @@ a.btn-info {
   background-color: #eee !important;
   border-color: #eee !important;
   color: #fff !important;
+  outline: none !important;
 }
 .btn-outline-white:active,
 .btn-outline-white:focus,
@@ -10571,6 +10586,7 @@ a.btn-info {
   background-color: var(--uog-color-black) !important;
   border-color: var(--uog-color-black) !important;
   color: var(--uog-color-black-contrast) !important;
+  outline: none !important;
 }
 a {
   color: var(--uog-color-body-copy-link);

--- a/src/index.css
+++ b/src/index.css
@@ -10800,7 +10800,8 @@ a:hover {
   color: var(--uog-color-body-copy-link-on-dark);
 }
 .bg-light a,
-.table-striped a {
+.table-striped a,
+.bg-light a.btn-outline-info {
   color: var(--uog-color-body-copy-link-on-light);
 }
 .site-content ul.menu.list-group {

--- a/src/index.css
+++ b/src/index.css
@@ -11069,7 +11069,7 @@ body {
 }
 a:active,
 a:focus {
-  outline: 0.1rem dotted var(--uog-color-yellow) !important;
+  outline: 2px solid var(--uog-color-body-copy-link) !important;
 }
 .author {
   border-left: 3px solid var(--uog-color-yellow);


### PR DESCRIPTION
- Change the link focus style to a 2px solid var(--uog-color-body-copy-link-on-light) border with no underline. (The blue should adapt depending on whether it's on bg-light or bg-dark)

Before:
<img width="285" alt="image" src="https://github.com/user-attachments/assets/026c4352-7d6b-45ac-b213-e896bcf16d69" />
After:
<img width="319" alt="image" src="https://github.com/user-attachments/assets/aad19f7e-b432-47ff-9a3a-fbdba5d9135d" />

- Update btn-outline-info so that the color meets colour contrast requirements on a bg-light background

Before:
<img width="347" alt="image" src="https://github.com/user-attachments/assets/fc7fb8d8-ee94-43e8-af45-2246451f3685" />

After:
<img width="415" alt="image" src="https://github.com/user-attachments/assets/9aa8f7fc-76fd-44e4-bbf5-804e69400222" />


# Testing URLs
- For link focus, use:
    - https://mmafe-dev.netlify.app/widget-examples/
    - https://mmafe-dev.netlify.app/media-and-text-examples/
- For contrast issues for btn-outline-info, test with https://mmafe-dev.netlify.app/lang/research/

# Recommend testing for
- All links, including widgets, UI components, etc.
- Contrast on regular, light, dark backgrounds