### PR TITLE
Correct heading 2 size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/uofg-styles",
-  "version": "3.0.3-rc.0",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/uofg-styles",
-      "version": "3.0.3-rc.0",
+      "version": "3.0.3",
       "license": "ISC",
       "devDependencies": {
         "autoprefixer": "^10.4.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uoguelph/uofg-styles",
-  "version": "3.0.2",
+  "version": "3.0.3-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uoguelph/uofg-styles",
-      "version": "3.0.2",
+      "version": "3.0.3-rc.0",
       "license": "ISC",
       "devDependencies": {
         "autoprefixer": "^10.4.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/uofg-styles",
-  "version": "3.0.2",
+  "version": "3.0.3-rc.0",
   "description": "A customized version of Bootstrap used for University of Guelph web pages",
   "main": "dist/index.css",
   "unpkg": "dist/index.css",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/uofg-styles",
-  "version": "3.0.3-rc.0",
+  "version": "3.0.3",
   "description": "A customized version of Bootstrap used for University of Guelph web pages",
   "main": "dist/index.css",
   "unpkg": "dist/index.css",

--- a/src/index.css
+++ b/src/index.css
@@ -10148,7 +10148,7 @@ h2 {
   clear: both;
   display: block;
   font-weight: 700;
-  font-size: 3.25rem;
+  font-size: 3rem;
 }
 .h3,
 h3 {


### PR DESCRIPTION
Correct heading 2 size to be 3 rem instead of 3.25 rem (as per branding guidelines)